### PR TITLE
fix: apis returning old data

### DIFF
--- a/app/api/last-played/route.ts
+++ b/app/api/last-played/route.ts
@@ -1,14 +1,12 @@
-import { NextRequest, NextResponse } from "next/server";
-
+import { NextResponse } from "next/server";
 import { getRecentlyPlayed } from "@/lib/spotify";
 
-export async function GET(req: NextRequest) {
+export const revalidate = 60;
+
+export async function GET() {
   const recentlyPlayed = await getRecentlyPlayed(1);
 
   return NextResponse.json(recentlyPlayed, {
     status: 200,
-    headers: {
-      "Cache-Control": "public, s-maxage=60, stale-while-revalidate=30",
-    },
   });
 }

--- a/app/api/listens/route.ts
+++ b/app/api/listens/route.ts
@@ -1,14 +1,12 @@
-import { NextRequest, NextResponse } from "next/server";
-
+import { NextResponse } from "next/server";
 import { getScrobbleCount } from "@/lib/lastfm";
 
-export async function GET(req: NextRequest) {
+export const revalidate = 60;
+
+export async function GET() {
   const scrobbleCount = await getScrobbleCount();
 
   return NextResponse.json(scrobbleCount, {
     status: 200,
-    headers: {
-      "Cache-Control": "public, s-maxage=60, stale-while-revalidate=30",
-    },
   });
 }

--- a/app/api/now-playing/route.ts
+++ b/app/api/now-playing/route.ts
@@ -1,14 +1,12 @@
-import { NextRequest, NextResponse } from "next/server";
-
+import { NextResponse } from "next/server";
 import { getNowPlaying } from "@/lib/spotify";
 
-export async function GET(req: NextRequest) {
+export const revalidate = 60;
+
+export async function GET() {
   const nowPlaying = await getNowPlaying();
 
   return NextResponse.json(nowPlaying, {
     status: 200,
-    headers: {
-      "Cache-Control": "public, s-maxage=60, stale-while-revalidate=30",
-    },
   });
 }

--- a/app/api/records/route.ts
+++ b/app/api/records/route.ts
@@ -1,15 +1,12 @@
-import { NextRequest, NextResponse } from "next/server";
-
+import { NextResponse } from "next/server";
 import { getCollectionSize } from "@/lib/discogs";
 
-export async function GET(req: NextRequest) {
+export const revalidate = 60 * 60 * 24;
+
+export async function GET() {
   const collectionSize = await getCollectionSize();
 
-  // TODO: Increase cache times on this, since my library size will hardly change
   return NextResponse.json(collectionSize, {
     status: 200,
-    headers: {
-      "Cache-Control": "public, s-maxage=60, stale-while-revalidate=30",
-    },
   });
 }

--- a/app/api/top-tracks/route.ts
+++ b/app/api/top-tracks/route.ts
@@ -1,14 +1,12 @@
-import { NextRequest, NextResponse } from "next/server";
-
+import { NextResponse } from "next/server";
 import { getTopTracks } from "@/lib/spotify";
 
-export async function GET(req: NextRequest) {
+export const revalidate = 60 * 60 * 24;
+
+export async function GET() {
   const topTracks = await getTopTracks();
 
   return NextResponse.json(topTracks, {
     status: 200,
-    headers: {
-      "Cache-Control": "public, s-maxage=60, stale-while-revalidate=30",
-    },
   });
 }


### PR DESCRIPTION
API's were returning old data. Turns out the new route handlers, and specifically the GET handlers, are evaluated statically and as such don't ever change. I've updated them to revalidate at certain intervals.