### PR TITLE
Improve Discogs records count getter

### DIFF
--- a/components/RecordsStat.tsx
+++ b/components/RecordsStat.tsx
@@ -3,8 +3,7 @@ import { Icon } from "@/components/Icon";
 import { getCollection } from "@/lib/discogs";
 
 export async function RecordsStat() {
-  const data = await getCollection();
-  const records = Object.keys(data).length;
+  const records = await getCollectionCount();
 
   return (
     <a

--- a/components/RecordsStat.tsx
+++ b/components/RecordsStat.tsx
@@ -1,6 +1,6 @@
 import { Counter } from "./Counter";
 import { Icon } from "@/components/Icon";
-import { getCollection } from "@/lib/discogs";
+import { getCollectionCount } from "@/lib/discogs";
 
 export async function RecordsStat() {
   const records = await getCollectionCount();

--- a/lib/discogs.ts
+++ b/lib/discogs.ts
@@ -5,13 +5,11 @@ invariant(process.env.DISCOGS_TOKEN, "`DISCOGS_TOKEN` should be set!");
 
 const token = process.env.DISCOGS_TOKEN;
 
-export async function getCollection() {
+export async function getCollectionCount() {
   const url = new URL(
     `https://api.discogs.com/users/nielsbik/collection/folders/0/releases`,
   );
   url.searchParams.append("token", token);
-  url.searchParams.append("per_page", "100");
-  url.searchParams.append("sort", "artist");
 
   const body = await fetcher(url.href, {
     headers: {
@@ -20,5 +18,5 @@ export async function getCollection() {
     next: { revalidate: 60 * 60 * 24 },
   });
 
-  return body.releases;
+  return body.pagination.items;
 }

--- a/lib/discogs.ts
+++ b/lib/discogs.ts
@@ -7,7 +7,7 @@ const token = process.env.DISCOGS_TOKEN;
 
 export async function getCollectionCount() {
   const url = new URL(
-    `https://api.discogs.com/users/nielsbik/collection/folders/0/releases`,
+    `https://api.discogs.com/users/nielsbik/collection/folders/0`,
   );
   url.searchParams.append("token", token);
 
@@ -18,5 +18,5 @@ export async function getCollectionCount() {
     next: { revalidate: 60 * 60 * 24 },
   });
 
-  return body.pagination.items;
+  return body.count;
 }


### PR DESCRIPTION
When you get more than 100 records, the old approach breaks. Just use the [folder info](https://www.discogs.com/developers/#page:user-collection,header:user-collection-collection-folder-get) to get the total number of records.